### PR TITLE
Fix payload content type absence error

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -16,11 +16,12 @@ var register = function (server, options, next) {
             options = Object.assign({}, options, v.value);
         }
 
-        var mime = Content.type(request.headers['content-type']).mime;       
-        if (mime === 'multipart/form-data' || mime === 'application/x-www-form-urlencoded') {     
-            Parser.parse(request, options);
+        if(request.headers['content-type']) {
+            var mime = Content.type(request.headers['content-type']).mime;       
+            if (mime === 'multipart/form-data' || mime === 'application/x-www-form-urlencoded') {     
+                Parser.parse(request, options);
+            }
         }
-
         return reply.continue();
     });
 


### PR DESCRIPTION
If there is no payload in POST/PUT/DELETE request the module throws an error, saying cannot read property 'match' of undefined, because it tries to read the property 'mime' of content type, but a content type is not present without payload.

We do send a payload in POST/PUT usually, but we often don't do that in DELETE.